### PR TITLE
Change `description` key to `summary` for new Mechanic behavior

### DIFF
--- a/RoboFabDocs.roboFontExt/info.plist
+++ b/RoboFabDocs.roboFontExt/info.plist
@@ -15,7 +15,7 @@
 	</array>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
-		<key>description</key>
+		<key>summary</key>
 		<string>The RoboFab Documentation as a RoboFont extension</string>
 		<key>repository</key>
 		<string>roboDocs/roboFabDocs</string>


### PR DESCRIPTION
Mechanic now looks for a key called `summary` in `info.plist`, so I'm updating the description key that you had already added to conform to the new addition to the spec.
